### PR TITLE
sip4 does not conflict with sip anymore

### DIFF
--- a/sip4/.SRCINFO
+++ b/sip4/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = sip4
 	pkgver = 4.19.25
-	pkgrel = 5
+	pkgrel = 6
 	url = https://www.riverbankcomputing.com/software/sip/intro
 	arch = x86_64
 	license = custom:"sip"
@@ -13,11 +13,10 @@ pkgbase = sip4
 pkgname = sip4
 	pkgdesc = A tool that makes it easy to create Python bindings for C and C++ libraries
 	depends = glibc
-	provides = sip
-	conflicts = sip
+	provides = sip4
 
 pkgname = python-sip4
 	pkgdesc = Python SIP4 bindings for C and C++ libraries
 	depends = python
-	provides = python-sip
-	replaces = python-sip
+	provides = python-sip4
+	replaces = python-sip4

--- a/sip4/PKGBUILD
+++ b/sip4/PKGBUILD
@@ -3,11 +3,12 @@
 # Contributor: Andrea Scarpino <andrea@archlinux.org>
 # Contributor: Douglas Soares de Andrade <douglas@archlinux.org>
 # Contributor: riai <riai@bigfoot.com>, Ben <ben@benmazer.net>
+# Contributor: Zhirui Dai <daizhirui@hotmail.com>
 
 pkgbase=sip4
 pkgname=(sip4 python-sip4)
 pkgver=4.19.25
-pkgrel=5
+pkgrel=6
 arch=(x86_64)
 url='https://www.riverbankcomputing.com/software/sip/intro'
 license=('custom:"sip"')
@@ -32,8 +33,7 @@ build() {
 package_sip4() {
   pkgdesc="A tool that makes it easy to create Python bindings for C and C++ libraries"
   depends=(glibc)
-  provides=(sip)
-  conflicts=(sip)
+  provides=(sip4)
 
   cd build
   make DESTDIR="$pkgdir" install -C sipgen
@@ -47,8 +47,8 @@ package_sip4() {
 package_python-sip4() {
   pkgdesc="Python SIP4 bindings for C and C++ libraries"
   depends=(python)
-  provides=(python-sip)
-  replaces=(python-sip)
+  provides=(python-sip4)
+  replaces=(python-sip4)
 
   cd build
   make DESTDIR="$pkgdir" install


### PR DESCRIPTION
`sip` is now provided as a python package that is installed at `/usr/lib/python*/site-packages/sipbuild`, which does not conflict with `sip4` at all. 
Same for `python-sip4`, it does not conflict with `sip` and it should not be labeled as providing `python-sip` because `python-sip` should be preserved for the latest `sip` release.